### PR TITLE
Making insurance plan optional for add and edit commands

### DIFF
--- a/src/main/java/seedu/iscam/logic/parser/clientcommands/AddCommandParser.java
+++ b/src/main/java/seedu/iscam/logic/parser/clientcommands/AddCommandParser.java
@@ -51,7 +51,7 @@ public class AddCommandParser implements Parser<AddCommand> {
                 ArgumentTokenizer.tokenize(
                         args, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_LOCATION, PREFIX_PLAN, PREFIX_TAG);
 
-        if (!arePrefixesPresent(argMultimap, PREFIX_NAME, PREFIX_LOCATION, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_PLAN)
+        if (!arePrefixesPresent(argMultimap, PREFIX_NAME, PREFIX_LOCATION, PREFIX_PHONE, PREFIX_EMAIL)
                 || !argMultimap.getPreamble().isEmpty()) {
             throw new ParseFormatException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE));
         }
@@ -59,7 +59,7 @@ public class AddCommandParser implements Parser<AddCommand> {
         Name name = ParserUtil.parseName(argMultimap.getValue(PREFIX_NAME).get());
         Phone phone = ParserUtil.parsePhone(argMultimap.getValue(PREFIX_PHONE).get());
         Email email = ParserUtil.parseEmail(argMultimap.getValue(PREFIX_EMAIL).get());
-        InsurancePlan plan = ParserUtil.parsePlan(argMultimap.getValue(PREFIX_PLAN).get());
+        InsurancePlan plan = ParserUtil.parsePlan(argMultimap.getValue(PREFIX_PLAN).orElse("No plans yet"));
         Set<Tag> tagList = ParserUtil.parseTags(argMultimap.getAllValues(PREFIX_TAG));
         Location location = ParserUtil.parseLocation(argMultimap.getValue(PREFIX_LOCATION).get());
 

--- a/src/main/java/seedu/iscam/logic/parser/clientcommands/EditCommandParser.java
+++ b/src/main/java/seedu/iscam/logic/parser/clientcommands/EditCommandParser.java
@@ -64,8 +64,16 @@ public class EditCommandParser implements Parser<EditCommand> {
             editClientDescriptor.setLocation(ParserUtil.parseLocation(argMultimap.getValue(PREFIX_LOCATION).get()));
         }
         if (argMultimap.getValue(PREFIX_PLAN).isPresent()) {
-            editClientDescriptor.setPlan(ParserUtil.parsePlan(argMultimap.getValue(PREFIX_PLAN).get()));
+            String planName = argMultimap.getValue(PREFIX_PLAN).get();
+
+            // If user input "ip/", Insurance Plan changes to "No plans yet"
+            if (planName.equals("")) {
+                planName = "No plans yet";
+            }
+
+            editClientDescriptor.setPlan(ParserUtil.parsePlan(planName));
         }
+
         parseTagsForEdit(argMultimap.getAllValues(PREFIX_TAG)).ifPresent(editClientDescriptor::setTags);
 
         if (!editClientDescriptor.isAnyFieldEdited()) {

--- a/src/main/java/seedu/iscam/model/client/Client.java
+++ b/src/main/java/seedu/iscam/model/client/Client.java
@@ -29,9 +29,10 @@ public class Client {
 
     /**
      * Every field must be present and not null.
+     * If insurance plan is not present, it will be a String of "No plans yet"
      */
     public Client(Name name, Phone phone, Email email, Location location, InsurancePlan plan, Set<Tag> tags) {
-        requireAllNonNull(name, phone, email, location, tags);
+        requireAllNonNull(name, phone, email, location, plan, tags);
         this.name = name;
         this.phone = phone;
         this.email = email;
@@ -119,9 +120,14 @@ public class Client {
                 .append("; Email: ")
                 .append(getEmail())
                 .append("; Location: ")
-                .append(getLocation())
-                .append("; Insurance Plan: ")
-                .append(getPlan());
+                .append(getLocation());
+
+        // If insurance plan is present, display it
+        InsurancePlan plan = getPlan();
+        if (!plan.toString().equals("No plans yet")) {
+            builder.append("; Insurance Plan: ")
+                    .append(getPlan());
+        }
 
         Set<Tag> tags = getTags();
         if (!tags.isEmpty()) {


### PR DESCRIPTION
### Changes made:
- /ip prefix is now optional for AddCommand
- EditCommand with just "/ip" i.e without the plan name will remove the existing Insurance Plan from client
- If Client does not have an Insurance Plan, it will still have an Insurance Plan object with plan name "No plans yet". This is because the Insurance Plan and the rest of the classes in AddressBook requires non-null, therefore a placeholder String name was used.
- In displaying the Client.toString(), Insurance Plan will only be displayed if the plan name is not "No plans yet"