### PR TITLE
Add an error message to list command when clientbook is empty

### DIFF
--- a/src/main/java/seedu/iscam/logic/commands/ListCommand.java
+++ b/src/main/java/seedu/iscam/logic/commands/ListCommand.java
@@ -3,7 +3,10 @@ package seedu.iscam.logic.commands;
 import static java.util.Objects.requireNonNull;
 import static seedu.iscam.model.Model.PREDICATE_SHOW_ALL_CLIENTS;
 
+import javafx.collections.ObservableList;
+import seedu.iscam.logic.commands.exceptions.CommandException;
 import seedu.iscam.model.Model;
+import seedu.iscam.model.client.Client;
 
 /**
  * Lists all clients in the iscam book to the user.
@@ -13,13 +16,18 @@ public class ListCommand extends Command {
     public static final String COMMAND_WORD = "list";
 
     public static final String MESSAGE_SUCCESS = "Listed all clients";
+    public static final String MESSAGE_EMPTY_LIST = "There is no client in the iScam book.";
 
 
     @Override
-    public CommandResult execute(Model model) {
+    public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
         model.updateFilteredClientList(PREDICATE_SHOW_ALL_CLIENTS);
         model.setClientMode();
+        ObservableList<Client> clients = model.getFilteredClientList();
+        if (clients.size() == 0) {
+            throw new CommandException(MESSAGE_EMPTY_LIST);
+        }
         return new CommandResult(MESSAGE_SUCCESS);
     }
 }

--- a/src/main/java/seedu/iscam/logic/commands/ListMeetingsCommand.java
+++ b/src/main/java/seedu/iscam/logic/commands/ListMeetingsCommand.java
@@ -16,7 +16,7 @@ public class ListMeetingsCommand extends Command {
     public static final String COMMAND_WORD = "listmeet";
 
     public static final String MESSAGE_SUCCESS = "Listed all meetings.";
-    public static final String MESSAGE_EMPTY_LIST = "There is no meeting in the iscam book.";
+    public static final String MESSAGE_EMPTY_LIST = "There is no meeting in the iScam book.";
 
     private String stringifyMeetings(ObservableList<Meeting> meetings) {
         String str = "";

--- a/src/test/java/seedu/iscam/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/iscam/logic/LogicManagerTest.java
@@ -19,8 +19,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 import seedu.iscam.logic.commands.AddCommand;
+import seedu.iscam.logic.commands.ClearCommand;
 import seedu.iscam.logic.commands.CommandResult;
-import seedu.iscam.logic.commands.ListCommand;
 import seedu.iscam.logic.commands.exceptions.CommandException;
 import seedu.iscam.logic.events.exceptions.EventException;
 import seedu.iscam.logic.parser.exceptions.ParseException;
@@ -70,8 +70,8 @@ public class LogicManagerTest {
 
     @Test
     public void execute_validCommand_success() throws Exception {
-        String listCommand = ListCommand.COMMAND_WORD;
-        assertCommandSuccess(listCommand, ListCommand.MESSAGE_SUCCESS, model);
+        String clearCommand = ClearCommand.COMMAND_WORD;
+        assertCommandSuccess(clearCommand, ClearCommand.MESSAGE_SUCCESS, model);
     }
 
     @Test


### PR DESCRIPTION
- Success message was displayed when `list` was called when clientbook is empty
- Error message implemented "There is no client in the iScam book"