### PR TITLE
Fix regression in editmeet caused by introducing date-time conflict check with existing meetings

### DIFF
--- a/src/main/java/seedu/iscam/logic/commands/EditMeetingCommand.java
+++ b/src/main/java/seedu/iscam/logic/commands/EditMeetingCommand.java
@@ -35,9 +35,6 @@ import seedu.iscam.model.meeting.Meeting;
 public class EditMeetingCommand extends Command {
 
     public static final String COMMAND_WORD = "editmeet";
-    public static final String PARAMETER_DONE = "yes";
-    public static final String PARAMETER_NOT_DONE = "no";
-
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Edits the details of the meeting identified "
             + "by the index number used in the displayed meeting list. "
             + "Existing values will be overwritten by the input values.\n"
@@ -51,7 +48,6 @@ public class EditMeetingCommand extends Command {
             + "Example: " + COMMAND_WORD + " 1 "
             + PREFIX_LOCATION + "Macdonald, Bedok "
             + PREFIX_DESCRIPTION + "Client's family will be coming along";
-
     public static final String MESSAGE_EDIT_MEETING_SUCCESS = "Edited Meeting: %1$s";
     public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";
     public static final String MESSAGE_DUPLICATE_MEETING = "No changes found in any field.";
@@ -113,7 +109,7 @@ public class EditMeetingCommand extends Command {
             throw new CommandException(MESSAGE_DUPLICATE_MEETING);
         }
 
-        if (model.hasConflictingMeetingWith(editedMeeting)) {
+        if (model.hasConflictingMeetingWith(editedMeeting, meeting)) {
             throw new CommandException(MESSAGE_CONFLICT);
         }
 

--- a/src/main/java/seedu/iscam/logic/commands/RescheduleMeetingCommand.java
+++ b/src/main/java/seedu/iscam/logic/commands/RescheduleMeetingCommand.java
@@ -55,7 +55,7 @@ public class RescheduleMeetingCommand extends Command {
         requireNonNull(model);
 
         ObservableList<Meeting> meetings = model.getFilteredMeetingList();
-        if (index.getZeroBased() >= meetings.size() || index.getZeroBased() < 0) {
+        if (index.getZeroBased() >= meetings.size()) {
             throw new CommandException(Messages.MESSAGE_INVALID_MEETING_DISPLAYED_INDEX);
         }
 

--- a/src/main/java/seedu/iscam/logic/commands/RescheduleMeetingCommand.java
+++ b/src/main/java/seedu/iscam/logic/commands/RescheduleMeetingCommand.java
@@ -55,7 +55,7 @@ public class RescheduleMeetingCommand extends Command {
         requireNonNull(model);
 
         ObservableList<Meeting> meetings = model.getFilteredMeetingList();
-        if (index.getZeroBased() >= meetings.size()) {
+        if (index.getZeroBased() >= meetings.size() || index.getZeroBased() < 0) {
             throw new CommandException(Messages.MESSAGE_INVALID_MEETING_DISPLAYED_INDEX);
         }
 

--- a/src/main/java/seedu/iscam/model/Model.java
+++ b/src/main/java/seedu/iscam/model/Model.java
@@ -141,7 +141,11 @@ public interface Model {
      */
     boolean hasMeeting(Meeting meeting);
 
-    boolean hasConflictingMeetingWith(Meeting meeting);
+    /**
+     * Returns true if any meeting except the ones in {@code exclusions} has conflicting date-time with {@code
+     * meeting}.
+     */
+    boolean hasConflictingMeetingWith(Meeting meeting, Meeting... exclusions);
 
     /**
      * Deletes the given meeting.

--- a/src/main/java/seedu/iscam/model/ModelManager.java
+++ b/src/main/java/seedu/iscam/model/ModelManager.java
@@ -174,9 +174,9 @@ public class ModelManager implements Model {
     }
 
     @Override
-    public boolean hasConflictingMeetingWith(Meeting meeting) {
+    public boolean hasConflictingMeetingWith(Meeting meeting, Meeting... exclusions) {
         requireNonNull(meeting);
-        return meetingBook.hasConflictingMeetingWith(meeting);
+        return meetingBook.hasConflictingMeetingWith(meeting, exclusions);
     }
 
     @Override

--- a/src/main/java/seedu/iscam/model/util/meetingbook/MeetingBook.java
+++ b/src/main/java/seedu/iscam/model/util/meetingbook/MeetingBook.java
@@ -2,6 +2,7 @@ package seedu.iscam.model.util.meetingbook;
 
 import static java.util.Objects.requireNonNull;
 
+import java.util.Arrays;
 import java.util.List;
 
 import javafx.collections.ObservableList;
@@ -62,13 +63,15 @@ public class MeetingBook implements ReadOnlyMeetingBook {
     }
 
     /**
-     * Returns true if the meeting shares the same date and time with any meeting in the iscam book.
+     * Returns true if any meeting except the ones in {@code exclusions} has conflicting date-time with {@code
+     * meeting}.
      */
-    public boolean hasConflictingMeetingWith(Meeting meeting) {
+    public boolean hasConflictingMeetingWith(Meeting meeting, Meeting... exclusions) {
         requireNonNull(meeting);
+
         for (Meeting other : meetings) {
             if (other.isInConflict(meeting) && !other.getClientName().equals(meeting.getClientName())) {
-                return true;
+                return Arrays.stream(exclusions).noneMatch(e -> other.getClientName().equals(e.getClientName()));
             }
         }
         return false;

--- a/src/test/java/seedu/iscam/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/iscam/logic/commands/AddCommandTest.java
@@ -176,7 +176,7 @@ public class AddCommandTest {
         }
 
         @Override
-        public boolean hasConflictingMeetingWith(Meeting meeting) {
+        public boolean hasConflictingMeetingWith(Meeting meeting, Meeting... exclusions) {
             throw new AssertionError("This method should not be called.");
         }
 


### PR DESCRIPTION
Fixes regression from #150.

Changes made:

- Excluded pre-edited meeting from the conflict check in editmeet.

