### PR TITLE
Address unclear error message for DateTime

### DIFF
--- a/src/main/java/seedu/iscam/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/iscam/logic/parser/ParserUtil.java
@@ -167,8 +167,10 @@ public class ParserUtil {
      */
     public static DateTime parseDateTime(String dateTimeStr) throws ParseException {
         requireNonNull(dateTimeStr);
-        if (!DateTime.isStringValidDateTime(dateTimeStr)) {
-            throw new ParseFormatException(DateTime.MESSAGE_CONSTRAINTS);
+        if (!DateTime.isStringValidFormat(dateTimeStr)) {
+            throw new ParseFormatException(DateTime.MESSAGE_INVALID_FORMAT);
+        } else if(!DateTime.isStringValidDateTime(dateTimeStr)) {
+            throw new ParseFormatException(DateTime.MESSAGE_IN_PAST);
         }
         return new DateTime(dateTimeStr);
     }

--- a/src/main/java/seedu/iscam/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/iscam/logic/parser/ParserUtil.java
@@ -169,7 +169,7 @@ public class ParserUtil {
         requireNonNull(dateTimeStr);
         if (!DateTime.isStringValidFormat(dateTimeStr)) {
             throw new ParseFormatException(DateTime.MESSAGE_INVALID_FORMAT);
-        } else if(!DateTime.isStringValidDateTime(dateTimeStr)) {
+        } else if (!DateTime.isStringValidDateTime(dateTimeStr)) {
             throw new ParseFormatException(DateTime.MESSAGE_IN_PAST);
         }
         return new DateTime(dateTimeStr);

--- a/src/main/java/seedu/iscam/model/meeting/DateTime.java
+++ b/src/main/java/seedu/iscam/model/meeting/DateTime.java
@@ -11,8 +11,8 @@ import java.time.format.DateTimeParseException;
  * Guarantees: immutable; is valid as declared in {@link #isStringValidDateTime(String)}
  */
 public class DateTime {
-    public static final String MESSAGE_CONSTRAINTS = "Date & time must be in the form of dd-MM-yyyy HH:mm and cannot "
-            + "be in the past.";
+    public static final String MESSAGE_INVALID_FORMAT = "Date and time should be of the format of dd-MM-yyyy HH:mm.";
+    public static final String MESSAGE_IN_PAST = "Date and time cannot be in the past.";
     public static final DateTimeFormatter DATETIME_PATTERN = DateTimeFormatter.ofPattern("dd-MM-yyyy HH:mm");
 
     public final LocalDateTime dateTime;

--- a/src/main/java/seedu/iscam/storage/meeting/JsonAdaptedMeeting.java
+++ b/src/main/java/seedu/iscam/storage/meeting/JsonAdaptedMeeting.java
@@ -87,7 +87,7 @@ class JsonAdaptedMeeting {
                     DateTime.class.getSimpleName()));
         }
         if (!DateTime.isStringValidFormat(dateTime)) {
-            throw new IllegalValueException(DateTime.MESSAGE_CONSTRAINTS);
+            throw new IllegalValueException(DateTime.MESSAGE_INVALID_FORMAT);
         }
         final DateTime modelDateTime = new DateTime(dateTime);
 

--- a/src/test/java/seedu/iscam/storage/meeting/JsonAdaptedMeetingTest.java
+++ b/src/test/java/seedu/iscam/storage/meeting/JsonAdaptedMeetingTest.java
@@ -65,7 +65,7 @@ public class JsonAdaptedMeetingTest {
         JsonAdaptedMeeting meeting =
                 new JsonAdaptedMeeting(VALID_NAME, INVALID_DATETIME, VALID_LOCATION,
                         VALID_DESCRIPTION, VALID_TAGS, VALID_STATUS);
-        String expectedMessage = DateTime.MESSAGE_CONSTRAINTS;
+        String expectedMessage = DateTime.MESSAGE_INVALID_FORMAT;
         assertThrows(IllegalValueException.class, expectedMessage, meeting::toModelType);
     }
 


### PR DESCRIPTION
Fixes #135.

Changes made:

- Splits constraint message of DateTime into 2 messages, 1 for invalid date-time format and 1 for date-time being in the past.