### PR TITLE
Restrict editing and rescheduling of meeting to uncompleted meetings

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -317,7 +317,6 @@ Format: `donemeet INDEX`
 
 * `INDEX` refer to the meeting's index number shown in the displayed meeting list from `listmeet`. The index **must be a 
   positive integer 1, 2, 3, …**
-* Meetings that are already completed will remain completed.
 
 ### Clearing all entries : `clear`
 

--- a/src/main/java/seedu/iscam/logic/commands/EditMeetingCommand.java
+++ b/src/main/java/seedu/iscam/logic/commands/EditMeetingCommand.java
@@ -105,7 +105,7 @@ public class EditMeetingCommand extends Command {
 
         if (meeting.getStatus().isComplete() && editedStatus.isEmpty()) {
             throw new CommandException(MESSAGE_NOT_ALLOWED);
-        } else if(meeting.getStatus().isComplete() && editedStatus.get().isComplete()) {
+        } else if (meeting.getStatus().isComplete() && editedStatus.get().isComplete()) {
             throw new CommandException(MESSAGE_ALREADY_COMPLETE);
         }
 

--- a/src/main/java/seedu/iscam/logic/commands/EditMeetingCommand.java
+++ b/src/main/java/seedu/iscam/logic/commands/EditMeetingCommand.java
@@ -53,6 +53,10 @@ public class EditMeetingCommand extends Command {
     public static final String MESSAGE_DUPLICATE_MEETING = "No changes found in any field.";
     public static final String MESSAGE_CONFLICT = "There is another meeting with the same date and time, consider "
             + "changing to another time.";
+    public static final String MESSAGE_NOT_ALLOWED = "This meeting was already completed, no modification can be made "
+            + "unless it is set back to incomplete.";
+    public static final String MESSAGE_ALREADY_COMPLETE = "This meeting was already completed, it cannot be complete "
+            + "again.";
 
     private final Index index;
     private final EditMeetingDescriptor editMeetingDescriptor;
@@ -90,21 +94,21 @@ public class EditMeetingCommand extends Command {
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
 
-        // Get a list of Meetings from model
         ObservableList<Meeting> meetings = model.getFilteredMeetingList();
-
-        // Throw exception if specified index is out of range
         if (index.getZeroBased() >= meetings.size()) {
             throw new CommandException(Messages.MESSAGE_INVALID_MEETING_DISPLAYED_INDEX);
         }
 
-        // Get Meeting specified by the index
         Meeting meeting = meetings.get(index.getZeroBased());
-
-        // Create an editing Meeting based on that Meeting
         Meeting editedMeeting = createEditedMeeting(meeting, editMeetingDescriptor);
+        Optional<CompletionStatus> editedStatus = editMeetingDescriptor.getStatus();
 
-        // Throw exception if that edited Meeting is a duplicate of the original
+        if (meeting.getStatus().isComplete() && editedStatus.isEmpty()) {
+            throw new CommandException(MESSAGE_NOT_ALLOWED);
+        } else if(meeting.getStatus().isComplete() && editedStatus.get().isComplete()) {
+            throw new CommandException(MESSAGE_ALREADY_COMPLETE);
+        }
+
         if (meeting.equals(editedMeeting)) {
             throw new CommandException(MESSAGE_DUPLICATE_MEETING);
         }
@@ -113,7 +117,6 @@ public class EditMeetingCommand extends Command {
             throw new CommandException(MESSAGE_CONFLICT);
         }
 
-        // Update Model and Meeting list
         model.setMeeting(meeting, editedMeeting);
         model.updateFilteredMeetingList(Model.PREDICATE_SHOW_ALL_MEETINGS);
         return new CommandResult(String.format(MESSAGE_EDIT_MEETING_SUCCESS, editedMeeting));

--- a/src/main/java/seedu/iscam/logic/commands/RescheduleMeetingCommand.java
+++ b/src/main/java/seedu/iscam/logic/commands/RescheduleMeetingCommand.java
@@ -32,8 +32,8 @@ public class RescheduleMeetingCommand extends Command {
             + "original.";
     public static final String MESSAGE_CONFLICT = "There is another meeting with the same date and time, consider "
             + "scheduling to another time.";
-    public static final String MESSAGE_ALREADY_COMPLETE = "This meeting was already completed, it cannot be " +
-            "rescheduled.";
+    public static final String MESSAGE_ALREADY_COMPLETE = "This meeting was already completed, it cannot be "
+            + "rescheduled.";
 
     private final Index index;
     private final DateTime dateTime;

--- a/src/main/java/seedu/iscam/logic/commands/RescheduleMeetingCommand.java
+++ b/src/main/java/seedu/iscam/logic/commands/RescheduleMeetingCommand.java
@@ -32,6 +32,8 @@ public class RescheduleMeetingCommand extends Command {
             + "original.";
     public static final String MESSAGE_CONFLICT = "There is another meeting with the same date and time, consider "
             + "scheduling to another time.";
+    public static final String MESSAGE_ALREADY_COMPLETE = "This meeting was already completed, it cannot be " +
+            "rescheduled.";
 
     private final Index index;
     private final DateTime dateTime;
@@ -61,6 +63,10 @@ public class RescheduleMeetingCommand extends Command {
 
         Meeting meeting = meetings.get(index.getZeroBased());
         Meeting rescheduledMeeting = rescheduleMeeting(meeting, dateTime);
+
+        if (meeting.getStatus().isComplete()) {
+            throw new CommandException(MESSAGE_ALREADY_COMPLETE);
+        }
 
         if (meeting.equals(rescheduledMeeting)) {
             throw new CommandException(MESSAGE_DUPLICATE_DATETIME);


### PR DESCRIPTION
Fixes #149. 

Changes made:

- Editmeet cannot modify any fields of a completed meeting unless it involves changing the status field.
- Reschedule cannot change the date of a completed meeting.
- Remove the statement that a completed meeting will remain completed in UG.