### PR TITLE
Correct DateTime to display error message when invalid date is given

### DIFF
--- a/src/main/java/seedu/iscam/model/meeting/DateTime.java
+++ b/src/main/java/seedu/iscam/model/meeting/DateTime.java
@@ -15,7 +15,7 @@ public class DateTime {
 
     public static final String MESSAGE_INVALID_FORMAT = "The given date-time is invalid. Possibly due to: \n"
             + ". Incorrect format (Should be of the format of dd-MM-yyyy HH:mm)\n"
-            + ". Invalid date (e.g. 29-02-2021, a date only valid in a leap year)";
+            + ". Invalid date (e.g. 29-02-2021, because 29-02 is not a valid date in a non-leap year)";
     public static final String MESSAGE_IN_PAST = "Date and time cannot be in the past.";
     public static final DateTimeFormatter DATETIME_PATTERN = DateTimeFormatter.ofPattern("dd-MM-uuuu HH:mm")
             .withResolverStyle(ResolverStyle.STRICT);

--- a/src/main/java/seedu/iscam/model/meeting/DateTime.java
+++ b/src/main/java/seedu/iscam/model/meeting/DateTime.java
@@ -5,15 +5,19 @@ import static java.util.Objects.requireNonNull;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
+import java.time.format.ResolverStyle;
 
 /**
  * Represents a meeting's date and time in the iscam book.
  * Guarantees: immutable; is valid as declared in {@link #isStringValidDateTime(String)}
  */
 public class DateTime {
-    public static final String MESSAGE_INVALID_FORMAT = "Date and time should be of the format of dd-MM-yyyy HH:mm.";
+    public static final String MESSAGE_INVALID_FORMAT = "The given date-time is invalid. Possibly due to: \n" +
+            ". Incorrect format (Should be of the format of dd-MM-yyyy HH:mm)\n" +
+            ". Invalid date (e.g. 29-02-2021, a date that is only valid in a leap year)";
     public static final String MESSAGE_IN_PAST = "Date and time cannot be in the past.";
-    public static final DateTimeFormatter DATETIME_PATTERN = DateTimeFormatter.ofPattern("dd-MM-yyyy HH:mm");
+    public static final DateTimeFormatter DATETIME_PATTERN = DateTimeFormatter.ofPattern("dd-MM-uuuu HH:mm")
+            .withResolverStyle(ResolverStyle.STRICT);
 
     public final LocalDateTime dateTime;
 

--- a/src/main/java/seedu/iscam/model/meeting/DateTime.java
+++ b/src/main/java/seedu/iscam/model/meeting/DateTime.java
@@ -12,9 +12,9 @@ import java.time.format.ResolverStyle;
  * Guarantees: immutable; is valid as declared in {@link #isStringValidDateTime(String)}
  */
 public class DateTime {
-    public static final String MESSAGE_INVALID_FORMAT = "The given date-time is invalid. Possibly due to: \n" +
-            ". Incorrect format (Should be of the format of dd-MM-yyyy HH:mm)\n" +
-            ". Invalid date (e.g. 29-02-2021, a date that is only valid in a leap year)";
+    public static final String MESSAGE_INVALID_FORMAT = "The given date-time is invalid. Possibly due to: \n"
+            + ". Incorrect format (Should be of the format of dd-MM-yyyy HH:mm)\n"
+            + ". Invalid date (e.g. 29-02-2021, a date that is only valid in a leap year)";
     public static final String MESSAGE_IN_PAST = "Date and time cannot be in the past.";
     public static final DateTimeFormatter DATETIME_PATTERN = DateTimeFormatter.ofPattern("dd-MM-uuuu HH:mm")
             .withResolverStyle(ResolverStyle.STRICT);


### PR DESCRIPTION
Fixes #153.

Changes made:

- DateTime no longer accept/auto-correct invalid dates.
- Invalid message from DateTime now indicates a possible cause of invalid dates being leap year's date.