### PR TITLE
Findmeet can now search by day of week

### DIFF
--- a/src/main/java/seedu/iscam/model/meeting/DateTime.java
+++ b/src/main/java/seedu/iscam/model/meeting/DateTime.java
@@ -11,9 +11,12 @@ import java.time.format.DateTimeParseException;
  * Guarantees: immutable; is valid as declared in {@link #isStringValidDateTime(String)}
  */
 public class DateTime {
+    public static final DateTimeFormatter DATETIME_PATTERN = DateTimeFormatter.ofPattern("dd-MM-yyyy HH:mm");
     public static final String MESSAGE_INVALID_FORMAT = "Date and time should be of the format of dd-MM-yyyy HH:mm.";
     public static final String MESSAGE_IN_PAST = "Date and time cannot be in the past.";
-    public static final DateTimeFormatter DATETIME_PATTERN = DateTimeFormatter.ofPattern("dd-MM-yyyy HH:mm");
+
+    private static final DateTimeFormatter DAY_OF_WEEK_FORMAT = DateTimeFormatter.ofPattern("EEE");
+    private static final DateTimeFormatter DAY_OF_WEEK_FORMAT_FULL = DateTimeFormatter.ofPattern("EEEE");
 
     public final LocalDateTime dateTime;
 
@@ -52,6 +55,14 @@ public class DateTime {
 
     public LocalDateTime get() {
         return this.dateTime;
+    }
+
+    public String getDayOfWeek() {
+        return this.dateTime.format(DAY_OF_WEEK_FORMAT).toLowerCase();
+    }
+
+    public String getDayOfWeekFull() {
+        return this.dateTime.format(DAY_OF_WEEK_FORMAT_FULL).toLowerCase();
     }
 
     @Override

--- a/src/main/java/seedu/iscam/model/meeting/MeetingContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/iscam/model/meeting/MeetingContainsKeywordsPredicate.java
@@ -38,6 +38,8 @@ public class MeetingContainsKeywordsPredicate implements Predicate<Meeting> {
             return keywords.stream()
                     .allMatch(keyword -> StringUtil.containsIgnoreCase(meeting.getClientName().toString(), keyword)
                         || StringUtil.containsIgnoreCase(meeting.getDateTime().toString(), keyword)
+                        || meeting.getDateTime().getDayOfWeek().equals(keyword.toLowerCase())
+                        || meeting.getDateTime().getDayOfWeekFull().equals(keyword.toLowerCase())
                         || StringUtil.containsIgnoreCase(meeting.getLocation().toString(), keyword)
                         || StringUtil.containsIgnoreCase(meeting.getDescription().toString(), keyword)
                         || meeting.getTags().stream()


### PR DESCRIPTION
Fixes #152.

Changes made:

- Day of the week added as a matching condition in findmeet's search process

Note. Day of week can be inputted in 2 formats, EEE or EEEE (eg. Thu or Thursday), and both are case-insensitive.