### PR TITLE
Sorting Meetings with uncompleted meetings at the top

### DIFF
--- a/src/main/java/seedu/iscam/model/ModelManager.java
+++ b/src/main/java/seedu/iscam/model/ModelManager.java
@@ -235,7 +235,6 @@ public class ModelManager implements Model {
         return filteredMeetings;
     }
 
-    //TODO: header
     @Override
     public void updateFilteredMeetingList(Predicate<Meeting> predicate) {
         requireNonNull(predicate);

--- a/src/main/java/seedu/iscam/model/meeting/UniqueMeetingList.java
+++ b/src/main/java/seedu/iscam/model/meeting/UniqueMeetingList.java
@@ -120,7 +120,13 @@ public class UniqueMeetingList implements Iterable<Meeting> {
     private class MeetingComparator implements Comparator<Meeting> {
         @Override
         public int compare(Meeting m1, Meeting m2) {
-            return m1.getDateTime().get().compareTo(m2.getDateTime().get());
+            if (m1.getStatus().isComplete() && !m2.getStatus().isComplete()) {
+                return 1;
+            } else if (!m1.getStatus().isComplete() && m2.getStatus().isComplete()) {
+                return -1;
+            } else {
+                return m1.getDateTime().get().compareTo(m2.getDateTime().get());
+            }
         }
     }
 }


### PR DESCRIPTION
Fixes #167.

Changes made:

- MeetingList now also considers the completion status of a meeting when it is sorting, incompleted meetings come first.