### PR TITLE
Removes the meeting list from success message for listmeet and findmeet

### DIFF
--- a/src/main/java/seedu/iscam/logic/commands/FindMeetingsCommand.java
+++ b/src/main/java/seedu/iscam/logic/commands/FindMeetingsCommand.java
@@ -2,10 +2,8 @@ package seedu.iscam.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 
-import javafx.collections.ObservableList;
 import seedu.iscam.commons.core.Messages;
 import seedu.iscam.model.Model;
-import seedu.iscam.model.meeting.Meeting;
 import seedu.iscam.model.meeting.MeetingContainsKeywordsPredicate;
 
 /**
@@ -27,20 +25,12 @@ public class FindMeetingsCommand extends Command {
         this.predicate = predicate;
     }
 
-    private String stringifyMeetings(ObservableList<Meeting> meetings) {
-        String str = "";
-        for (int i = 0; i < meetings.size(); i++) {
-            str += meetings.get(i).toString() + "\n";
-        }
-        return str;
-    }
-
     @Override
     public CommandResult execute(Model model) {
         requireNonNull(model);
         model.updateFilteredMeetingList(predicate);
         return new CommandResult(String.format(Messages.MESSAGE_MEETINGS_LISTED_OVERVIEW,
-                model.getFilteredMeetingList().size()) + "\n" + stringifyMeetings(model.getFilteredMeetingList()));
+                model.getFilteredMeetingList().size()));
     }
 
     @Override

--- a/src/main/java/seedu/iscam/logic/commands/ListMeetingsCommand.java
+++ b/src/main/java/seedu/iscam/logic/commands/ListMeetingsCommand.java
@@ -18,14 +18,6 @@ public class ListMeetingsCommand extends Command {
     public static final String MESSAGE_SUCCESS = "Listed all meetings.";
     public static final String MESSAGE_EMPTY_LIST = "There is no meeting in the iScam book.";
 
-    private String stringifyMeetings(ObservableList<Meeting> meetings) {
-        String str = "";
-        for (int i = 0; i < meetings.size(); i++) {
-            str += meetings.get(i).toString() + "\n";
-        }
-        return str;
-    }
-
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
@@ -34,6 +26,6 @@ public class ListMeetingsCommand extends Command {
         if (meetings.size() == 0) {
             throw new CommandException(MESSAGE_EMPTY_LIST);
         }
-        return new CommandResult(MESSAGE_SUCCESS + "\n" + stringifyMeetings(meetings));
+        return new CommandResult(MESSAGE_SUCCESS);
     }
 }

--- a/src/test/java/seedu/iscam/logic/commands/FindMeetingsCommandTest.java
+++ b/src/test/java/seedu/iscam/logic/commands/FindMeetingsCommandTest.java
@@ -56,7 +56,7 @@ public class FindMeetingsCommandTest {
 
     @Test
     public void execute_zeroKeywords_noMeetingFound() {
-        String expectedMessage = String.format(MESSAGE_MEETINGS_LISTED_OVERVIEW + "\n", 0);
+        String expectedMessage = String.format(MESSAGE_MEETINGS_LISTED_OVERVIEW, 0);
         MeetingContainsKeywordsPredicate predicate = preparePredicate(" ");
         FindMeetingsCommand command = new FindMeetingsCommand(predicate);
         expectedModel.updateFilteredMeetingList(predicate);
@@ -66,8 +66,7 @@ public class FindMeetingsCommandTest {
 
     @Test
     public void execute_multipleKeywords_multipleMeetingsFound() {
-        String expectedMessage = String.format(MESSAGE_MEETINGS_LISTED_OVERVIEW + "\n" + FIONA_1
-                + "\n" + FIONA_2 + "\n", 2);
+        String expectedMessage = String.format(MESSAGE_MEETINGS_LISTED_OVERVIEW, 2);
         MeetingContainsKeywordsPredicate predicate = preparePredicate("Kunz");
         FindMeetingsCommand command = new FindMeetingsCommand(predicate);
         expectedModel.updateFilteredMeetingList(predicate);

--- a/src/test/java/seedu/iscam/logic/commands/ListMeetingsCommandTest.java
+++ b/src/test/java/seedu/iscam/logic/commands/ListMeetingsCommandTest.java
@@ -4,14 +4,6 @@ import static seedu.iscam.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.iscam.logic.commands.CommandTestUtil.showMeetingAtIndex;
 import static seedu.iscam.testutil.TypicalClients.getTypicalClientBook;
 import static seedu.iscam.testutil.TypicalIndexes.INDEX_FIRST_ITEM;
-import static seedu.iscam.testutil.TypicalMeetings.ALICE_1;
-import static seedu.iscam.testutil.TypicalMeetings.ALICE_2;
-import static seedu.iscam.testutil.TypicalMeetings.BENSON_1;
-import static seedu.iscam.testutil.TypicalMeetings.CARL_1;
-import static seedu.iscam.testutil.TypicalMeetings.DANIEL_1;
-import static seedu.iscam.testutil.TypicalMeetings.ELLE_1;
-import static seedu.iscam.testutil.TypicalMeetings.FIONA_1;
-import static seedu.iscam.testutil.TypicalMeetings.FIONA_2;
 import static seedu.iscam.testutil.TypicalMeetings.getTypicalMeetingBook;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -37,18 +29,12 @@ public class ListMeetingsCommandTest {
 
     @Test
     public void execute_listIsNotFiltered_showsSameList() {
-        assertCommandSuccess(new ListMeetingsCommand(), model, ListMeetingsCommand.MESSAGE_SUCCESS
-                + "\n" + ALICE_1 + "\n" + ALICE_2 + "\n" + BENSON_1
-                + "\n" + DANIEL_1 + "\n" + ELLE_1 + "\n" + FIONA_1
-                + "\n" + FIONA_2 + "\n" + CARL_1 + "\n", expectedModel);
+        assertCommandSuccess(new ListMeetingsCommand(), model, ListMeetingsCommand.MESSAGE_SUCCESS, expectedModel);
     }
 
     @Test
     public void execute_listIsFiltered_showsEverything() {
         showMeetingAtIndex(model, INDEX_FIRST_ITEM);
-        assertCommandSuccess(new ListMeetingsCommand(), model, ListMeetingsCommand.MESSAGE_SUCCESS
-                + "\n" + ALICE_1 + "\n" + ALICE_2 + "\n" + BENSON_1
-                + "\n" + DANIEL_1 + "\n" + ELLE_1 + "\n" + FIONA_1
-                + "\n" + FIONA_2 + "\n" + CARL_1 + "\n", expectedModel);
+        assertCommandSuccess(new ListMeetingsCommand(), model, ListMeetingsCommand.MESSAGE_SUCCESS, expectedModel);
     }
 }


### PR DESCRIPTION
Fixes #234.

Changes made:

- Success message for listmeet and findmeet no longer list down meetings to be consistent with the corresponding client commands
- Updated the tests for listmeet and findmeet to be in sync with the change