### PR TITLE
Corrects sample data json to work with client list

### DIFF
--- a/src/main/java/seedu/iscam/model/util/SampleDataUtil.java
+++ b/src/main/java/seedu/iscam/model/util/SampleDataUtil.java
@@ -49,13 +49,13 @@ public class SampleDataUtil {
 
     public static Meeting[] getSampleMeetings() {
         return new Meeting[]{
-            new Meeting(new Name("Client A"), new DateTime("12-10-2021 10:00"),
+            new Meeting(new Name("Alex Yeoh"), new DateTime("12-10-2021 10:00"),
                     new Location("Starbucks, Paya Lebar Square"), new Description("Sell insurance plan"),
                     getTagSet("Urgent")),
-            new Meeting(new Name("Client B"), new DateTime("13-10-2021 10:00"),
+            new Meeting(new Name("Charlotte Oliveiro"), new DateTime("13-10-2022 12:00"),
                     new Location("Coffee Bean, NUH"), new Description("Sell insurance plan"),
                     getTagSet("Urgent")),
-            new Meeting(new Name("Client C"), new DateTime("14-10-2021 10:00"),
+            new Meeting(new Name("Roy Balakrishnan"), new DateTime("14-10-2023 14:00"),
                     new Location("Toast Box, NEX"), new Description("Sell insurance plan"),
                     getTagSet("Urgent"))
         };


### PR DESCRIPTION
Fixes #231.

Changes made:

- Client names in sample json's meetings now use the name of the clients in the sample json.
- Dates in those meetings are pushed back to prevent any conflict in the near future.